### PR TITLE
Restore the margins of Note in Lite Version

### DIFF
--- a/components/note.tsx
+++ b/components/note.tsx
@@ -25,7 +25,7 @@ export default function Note({
   return (
     <div
       className={cn(
-        "border rounded-md py-0.5 px-3.5 text-sm tracking-wide",
+        "border rounded-md py-0.5 px-3.5 text-sm tracking-wide mt-5 mb-7",
         noteClassNames
       )}
     >


### PR DESCRIPTION
I found that the margin of the node in Lite Version was not appropriate, so I restored it.

Before
![image](https://github.com/user-attachments/assets/d851457f-94b7-41a5-93e5-93c80df1ac9c)
After
![image](https://github.com/user-attachments/assets/2ea0043d-0b55-4553-8c3b-3a24815c5a00)
