### PR TITLE
Fix ToC link in docs by replacing Link with a tag

### DIFF
--- a/react-router-base/app/components/toc-observer.tsx
+++ b/react-router-base/app/components/toc-observer.tsx
@@ -1,7 +1,6 @@
 import { type getDocsTocs } from "~/lib/markdown";
 import clsx from "clsx";
 import { useState, useRef, useEffect } from "react";
-import { Link } from "react-router";
 
 type Props = { data: Awaited<ReturnType<typeof getDocsTocs>> };
 
@@ -48,9 +47,9 @@ export default function TocObserver({ data }: Props) {
     <div className="flex flex-col gap-2.5 text-sm dark:text-stone-300/85 text-stone-800 ml-0.5">
       {data.map(({ href, level, text }, index) => {
         return (
-          <Link
+          <a
             key={href + text + level + index}
-            to={href}
+            href={href}
             className={clsx({
               "pl-0": level == 2,
               "pl-4": level == 3,
@@ -60,7 +59,7 @@ export default function TocObserver({ data }: Props) {
             })}
           >
             {text}
-          </Link>
+          </a>
         );
       })}
     </div>

--- a/tanstack-start-base/app/components/toc-observer.tsx
+++ b/tanstack-start-base/app/components/toc-observer.tsx
@@ -1,5 +1,4 @@
 import { type getDocsTocs } from "@/lib/markdown-server";
-import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
 import { useState, useRef, useEffect } from "react";
 
@@ -48,9 +47,9 @@ export default function TocObserver({ data }: Props) {
     <div className="flex flex-col gap-2.5 text-sm dark:text-stone-300/85 text-stone-800 ml-0.5">
       {data.map(({ href, level, text }, index) => {
         return (
-          <Link
+          <a
             key={href + text + level + index}
-            to={href}
+            href={href}
             className={clsx({
               "pl-0": level == 2,
               "pl-4": level == 3,
@@ -60,7 +59,7 @@ export default function TocObserver({ data }: Props) {
             })}
           >
             {text}
-          </Link>
+          </a>
         );
       })}
     </div>


### PR DESCRIPTION
This PR fixes an issue where ToC anchor links like `#project-overview` are incorrectly rendered when using the `Link` component from TanStack Router.

For example:
http://localhost:3000/docs/#project-overview → 404 error

Instead, the correct behavior should be:
http://localhost:3000/docs/getting-started/introduction#project-overview ✅

This fix replaces the `Link` component with a native `<a href="#...">` tag to support proper in-page anchors.

Results: 
![Screenshot from 2025-04-14 00-56-34](https://github.com/user-attachments/assets/f154f6bb-1619-42f6-8d88-37388bb7bf2e)


Closes #37